### PR TITLE
PHP 8.2 compatability, Card Comment Update and Missing params on filter

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [7.3, 7.4, 8.0, 8.1]
+                php: [7.3, 7.4, 8.0, 8.1, 8.2]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }}

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.3|^8.0|^8.1",
+        "php": "^7.3|^8.0|^8.1|^8.2",
         "php-http/discovery": "^1.6",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",

--- a/src/Api/Board/BoardCardListsApi.php
+++ b/src/Api/Board/BoardCardListsApi.php
@@ -30,9 +30,9 @@ class BoardCardListsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/board/#get-1-boards-board-id-lists-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -40,12 +40,12 @@ class BoardCardListsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/board/#get-1-boards-board-id-lists-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $allowed = ['all', 'none', 'open', 'closed'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 
     /**

--- a/src/Api/Board/BoardCardsApi.php
+++ b/src/Api/Board/BoardCardsApi.php
@@ -30,9 +30,9 @@ class BoardCardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/board/#get-1-boards-board-id-cards-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -40,12 +40,12 @@ class BoardCardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/board/#get-1-boards-board-id-cards-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $allowed = ['all', 'visible', 'none', 'open', 'closed'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 
     /**

--- a/src/Api/Board/BoardMembersApi.php
+++ b/src/Api/Board/BoardMembersApi.php
@@ -47,9 +47,9 @@ class BoardMembersApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/board/#get-1-boards-board-id-members-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -57,12 +57,12 @@ class BoardMembersApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/board/#get-1-boards-board-id-members-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $allowed = ['none', 'normal', 'admins', 'owners', 'all'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 
     /**

--- a/src/Api/Card/CardActionsApi.php
+++ b/src/Api/Card/CardActionsApi.php
@@ -38,6 +38,18 @@ class CardActionsApi extends AbstractApi
     }
 
     /**
+     * Update comment on a given card.
+     *
+     * @see https://developer.atlassian.com/cloud/trello/rest/api-group-cards/#api-cards-id-actions-idaction-comments-put
+     */
+    public function updateComment(string $id, string $commentId, string $text): array
+    {
+        return $this->put($this->getPath($id).'/'.rawurlencode($commentId).'/comments', [
+            'text' => $text,
+        ]);
+    }
+
+    /**
      * Remove comment to a given card.
      *
      * @see https://trello.com/docs/api/card/#delete-1-cards-card-id-or-shortlink-actions-idaction-comments

--- a/src/Api/CardList/CardListCardsApi.php
+++ b/src/Api/CardList/CardListCardsApi.php
@@ -30,9 +30,9 @@ class CardListCardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/list/#get-1-lists-idlist-cards-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -40,12 +40,12 @@ class CardListCardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/list/#get-1-lists-idlist-cards-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $allowed = ['none', 'open', 'closed', 'all'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 
     /**

--- a/src/Api/Checklist/ChecklistCardsApi.php
+++ b/src/Api/Checklist/ChecklistCardsApi.php
@@ -30,9 +30,9 @@ class ChecklistCardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/checklist/#get-1-checklists-idchecklist-cards-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -40,11 +40,11 @@ class ChecklistCardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/checklist/#get-1-checklists-idchecklist-cards-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $allowed = ['none', 'open', 'closed', 'all'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 }

--- a/src/Api/Member/MemberBoardsApi.php
+++ b/src/Api/Member/MemberBoardsApi.php
@@ -33,9 +33,9 @@ class MemberBoardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/member/#get-1-members-idmember-or-username-boards-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -48,7 +48,7 @@ class MemberBoardsApi extends AbstractApi
         $allowed = ['all', 'members', 'organization', 'public', 'open', 'closed', 'pinned', 'unpinned', 'starred'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 
     /**

--- a/src/Api/Member/MemberBoardsApi.php
+++ b/src/Api/Member/MemberBoardsApi.php
@@ -43,7 +43,7 @@ class MemberBoardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/member/#get-1-members-idmember-or-username-boards-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $allowed = ['all', 'members', 'organization', 'public', 'open', 'closed', 'pinned', 'unpinned', 'starred'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');

--- a/src/Api/Member/MemberCardsApi.php
+++ b/src/Api/Member/MemberCardsApi.php
@@ -30,9 +30,9 @@ class MemberCardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/list/#get-1-lists-idlist-cards-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -40,11 +40,11 @@ class MemberCardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/list/#get-1-lists-idlist-cards-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $allowed = ['none', 'visible', 'open', 'closed', 'all'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 }

--- a/src/Api/Member/MemberNotificationsApi.php
+++ b/src/Api/Member/MemberNotificationsApi.php
@@ -31,9 +31,9 @@ class MemberNotificationsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/member/#get-1-members-idmember-or-username-notifications-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -41,13 +41,13 @@ class MemberNotificationsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/member/#get-1-members-idmember-or-username-notifications-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $events = WebhookEvents::all();
         $events[] = 'all';
 
         $filters = $this->validateAllowedParameters($events, $filters, 'event');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 }

--- a/src/Api/Member/MemberOrganizationsApi.php
+++ b/src/Api/Member/MemberOrganizationsApi.php
@@ -31,9 +31,9 @@ class MemberOrganizationsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/member/#get-1-members-idmember-or-username-organizations-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -41,12 +41,12 @@ class MemberOrganizationsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/member/#get-1-members-idmember-or-username-organizations-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $allowed = ['all', 'none', 'members', 'public'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 
     /**

--- a/src/Api/Organization/OrganizationBoardsApi.php
+++ b/src/Api/Organization/OrganizationBoardsApi.php
@@ -25,9 +25,9 @@ class OrganizationBoardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/organization/#get-1-organizations-idorganization-or-username-boards-filter
      */
-    public function filter(string $id, string $filter = 'all'): array
+    public function filter(string $id, string $filter = 'all', array $params = []): array
     {
-        return $this->filters($id, [$filter]);
+        return $this->filters($id, [$filter], $params);
     }
 
     /**
@@ -40,6 +40,6 @@ class OrganizationBoardsApi extends AbstractApi
         $allowed = ['all', 'members', 'organization', 'public', 'open', 'closed', 'starred'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');
 
-        return $this->get($this->getPath($id).'/'.implode(',', $filters));
+        return $this->get($this->getPath($id).'/'.implode(',', $filters), $params);
     }
 }

--- a/src/Api/Organization/OrganizationBoardsApi.php
+++ b/src/Api/Organization/OrganizationBoardsApi.php
@@ -35,7 +35,7 @@ class OrganizationBoardsApi extends AbstractApi
      *
      * @see https://trello.com/docs/api/organization/#get-1-organizations-idorganization-or-username-boards-filter
      */
-    public function filters(string $id, array $filters): array
+    public function filters(string $id, array $filters, array $params = []): array
     {
         $allowed = ['all', 'members', 'organization', 'public', 'open', 'closed', 'starred'];
         $filters = $this->validateAllowedParameters($allowed, $filters, 'filter');

--- a/tests/Api/Card/CardActionsApiTest.php
+++ b/tests/Api/Card/CardActionsApiTest.php
@@ -51,6 +51,24 @@ class CardActionsApiTest extends ApiTestCase
     /**
      * @test
      */
+    public function shouldUpdateComment(): void
+    {
+        $response = ['response'];
+
+        $text = 'Comment text updated';
+
+        $api = $this->getApiMock();
+        $api->expects(static::once())
+            ->method('put')
+            ->with($this->getPath().'/'.$this->fakeId.'/comments')
+            ->willReturn($response);
+
+        static::assertEquals($response, $api->updateComment($this->fakeParentId, $this->fakeId, $text));
+    }
+
+    /**
+     * @test
+     */
     public function shouldRemoveComment(): void
     {
         $response = ['response'];


### PR DESCRIPTION
1. Add compatability with PHP 8.2 via composer and workflow.
2. Add ability to update comments via Card Actions API.
3. Add missing `$params` to all filter() functions. The params are required to apply `limit`, `before` and `since`, otherwise fetch on massive boards is impossible.